### PR TITLE
adds `sortedcontainers` as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         'paramiko',
         'screeninfo',
         'pynput',
-        'remarkable-mouse'
+        'remarkable-mouse',
+        'sortedcontainers'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
seems this was missing, gave me immediate error on test run after installing in `pipenv` -- please deny request if this is an unneeded dependency and reference can be removed in `mappings.py`